### PR TITLE
refactor(chain): unify send/receive with sendAndReceive utility

### DIFF
--- a/src/main/java/net/result/main/RunHubWork.java
+++ b/src/main/java/net/result/main/RunHubWork.java
@@ -62,7 +62,7 @@ public class RunHubWork implements Work {
                 if (!console.running) return;
                 throw new RuntimeException(e);
             }
-        });
+        }, "Socket-Accepting");
         thread.setDaemon(true);
         thread.start();
 

--- a/src/main/java/net/result/sandnode/chain/BaseChain.java
+++ b/src/main/java/net/result/sandnode/chain/BaseChain.java
@@ -116,6 +116,12 @@ public abstract class BaseChain implements Chain {
         sendIgnoreQueue(message);
     }
 
+    protected RawMessage sendAndReceive(Message message) throws UnprocessedMessagesException, InterruptedException,
+            UnknownSandnodeErrorException, SandnodeErrorException {
+        send(message);
+        return receive();
+    }
+
     @Override
     public int compareTo(@NotNull Chain chain) {
         return compareID(chain.getID());

--- a/src/main/java/net/result/sandnode/chain/sender/ClusterClientChain.java
+++ b/src/main/java/net/result/sandnode/chain/sender/ClusterClientChain.java
@@ -7,6 +7,7 @@ import net.result.sandnode.exception.UnprocessedMessagesException;
 import net.result.sandnode.exception.error.SandnodeErrorException;
 import net.result.sandnode.message.types.ClusterRequest;
 import net.result.sandnode.message.types.ClusterResponse;
+import net.result.sandnode.message.util.Headers;
 import net.result.sandnode.serverclient.SandnodeClient;
 
 import java.util.Collection;
@@ -18,17 +19,15 @@ public class ClusterClientChain extends ClientChain {
 
     public Collection<String> remove(Collection<String> clusters) throws InterruptedException, ExpectedMessageException,
             UnprocessedMessagesException, UnknownSandnodeErrorException, SandnodeErrorException {
-        ClusterRequest request = new ClusterRequest(clusters);
-        request.headers().setValue("mode", "remove");
-        send(request);
-        return new ClusterResponse(receive()).getClustersID();
+        ClusterRequest request = new ClusterRequest(new Headers().setValue("mode", "remove"), clusters);
+        var raw = sendAndReceive(request);
+        return new ClusterResponse(raw).getClustersID();
     }
 
     public Collection<String> add(Collection<String> clusters) throws InterruptedException, ExpectedMessageException,
             UnprocessedMessagesException, UnknownSandnodeErrorException, SandnodeErrorException {
-        ClusterRequest request = new ClusterRequest(clusters);
-        request.headers().setValue("mode", "add");
-        send(request);
-        return new ClusterResponse(receive()).getClustersID();
+        ClusterRequest request = new ClusterRequest(new Headers().setValue("mode", "add"), clusters);
+        var raw = sendAndReceive(request);
+        return new ClusterResponse(raw).getClustersID();
     }
 }

--- a/src/main/java/net/result/sandnode/chain/sender/DEKClientChain.java
+++ b/src/main/java/net/result/sandnode/chain/sender/DEKClientChain.java
@@ -10,6 +10,7 @@ import net.result.sandnode.exception.crypto.CryptoException;
 import net.result.sandnode.exception.crypto.EncryptionTypeException;
 import net.result.sandnode.exception.crypto.NoSuchEncryptionException;
 import net.result.sandnode.exception.error.SandnodeErrorException;
+import net.result.sandnode.message.RawMessage;
 import net.result.sandnode.message.UUIDMessage;
 import net.result.sandnode.message.types.DEKListMessage;
 import net.result.sandnode.message.types.DEKRequest;
@@ -27,8 +28,8 @@ public class DEKClientChain extends ClientChain {
     public UUID sendDEK(String nickname, KeyDTO encryptor, KeyStorage keyStorage)
             throws InterruptedException, SandnodeErrorException, UnknownSandnodeErrorException,
             UnprocessedMessagesException, CryptoException, DeserializationException {
-        send(DEKRequest.send(nickname, encryptor, keyStorage));
-        return new UUIDMessage(receive()).uuid;
+        RawMessage raw = sendAndReceive(DEKRequest.send(nickname, encryptor, keyStorage));
+        return new UUIDMessage(raw).uuid;
     }
 
     public UUID sendDEK(String nickname, UUID encryptorID, KeyStorage keyStorage)
@@ -40,15 +41,15 @@ public class DEKClientChain extends ClientChain {
 
     public Collection<DEKDTO> get() throws UnprocessedMessagesException, InterruptedException,
             UnknownSandnodeErrorException, SandnodeErrorException, ExpectedMessageException, DeserializationException {
-        send(DEKRequest.get());
-        return new DEKListMessage(receive()).list();
+        RawMessage raw = sendAndReceive(DEKRequest.get());
+        return new DEKListMessage(raw).list();
     }
 
     public KeyDTO getKeyOf(String nickname) throws ExpectedMessageException, InterruptedException,
             UnknownSandnodeErrorException, SandnodeErrorException, UnprocessedMessagesException,
             EncryptionTypeException, NoSuchEncryptionException, CreatingKeyException, StorageException {
-        send(DEKRequest.getPersonalKeyOf(nickname));
-        KeyDTO key = PublicKeyResponse.getKeyDTO(receive());
+        RawMessage raw = sendAndReceive(DEKRequest.getPersonalKeyOf(nickname));
+        KeyDTO key = PublicKeyResponse.getKeyDTO(raw);
 
         client.node.agent().config.saveEncryptor(client.address, nickname, key.keyID(), key.keyStorage());
 

--- a/src/main/java/net/result/sandnode/chain/sender/LogPasswdClientChain.java
+++ b/src/main/java/net/result/sandnode/chain/sender/LogPasswdClientChain.java
@@ -7,7 +7,6 @@ import net.result.sandnode.exception.ExpectedMessageException;
 import net.result.sandnode.exception.UnknownSandnodeErrorException;
 import net.result.sandnode.exception.UnprocessedMessagesException;
 import net.result.sandnode.exception.error.SandnodeErrorException;
-import net.result.sandnode.message.RawMessage;
 import net.result.sandnode.message.types.LogPasswdRequest;
 import net.result.sandnode.message.types.LogPasswdResponse;
 import net.result.sandnode.serverclient.SandnodeClient;
@@ -20,13 +19,7 @@ public class LogPasswdClientChain extends ClientChain {
     public LogPasswdResponseDTO getToken(String nickname, String password, String device)
             throws InterruptedException, SandnodeErrorException, ExpectedMessageException,
             UnknownSandnodeErrorException, UnprocessedMessagesException, DeserializationException {
-        LogPasswdRequest loginRequest = new LogPasswdRequest(nickname, password, device);
-        send(loginRequest);
-
-        RawMessage message = receive();
-
-        LogPasswdResponse loginResponse = new LogPasswdResponse(message);
-
-        return loginResponse.dto();
+        var raw = sendAndReceive(new LogPasswdRequest(nickname, password, device));
+        return new LogPasswdResponse(raw).dto();
     }
 }

--- a/src/main/java/net/result/sandnode/chain/sender/LoginClientChain.java
+++ b/src/main/java/net/result/sandnode/chain/sender/LoginClientChain.java
@@ -34,13 +34,7 @@ public class LoginClientChain extends ClientChain {
 
     public synchronized List<LoginHistoryDTO> getHistory() throws UnprocessedMessagesException, InterruptedException,
             UnknownSandnodeErrorException, SandnodeErrorException, DeserializationException, ExpectedMessageException {
-        LoginRequest loginRequest = LoginRequest.history(new Headers());
-        send(loginRequest);
-
-        RawMessage raw = receive();
-
-        LoginHistoryResponse loginResponse = new LoginHistoryResponse(raw);
-
-        return loginResponse.history();
+        RawMessage raw = sendAndReceive(LoginRequest.history(new Headers()));
+        return new LoginHistoryResponse(raw).history();
     }
 }

--- a/src/main/java/net/result/sandnode/chain/sender/LogoutClientChain.java
+++ b/src/main/java/net/result/sandnode/chain/sender/LogoutClientChain.java
@@ -6,7 +6,6 @@ import net.result.sandnode.exception.UnknownSandnodeErrorException;
 import net.result.sandnode.exception.UnprocessedMessagesException;
 import net.result.sandnode.exception.error.SandnodeErrorException;
 import net.result.sandnode.message.EmptyMessage;
-import net.result.sandnode.message.types.HappyMessage;
 import net.result.sandnode.message.util.Headers;
 import net.result.sandnode.message.util.MessageTypes;
 import net.result.sandnode.serverclient.SandnodeClient;
@@ -18,7 +17,6 @@ public class LogoutClientChain extends ClientChain {
 
     public synchronized void logout() throws UnprocessedMessagesException, InterruptedException,
             ExpectedMessageException, UnknownSandnodeErrorException, SandnodeErrorException {
-        send(new EmptyMessage(new Headers().setType(MessageTypes.LOGOUT)));
-        new HappyMessage(receive());
+        sendAndReceive(new EmptyMessage(new Headers().setType(MessageTypes.LOGOUT))).expect(MessageTypes.HAPPY);
     }
 }

--- a/src/main/java/net/result/sandnode/chain/sender/NameClientChain.java
+++ b/src/main/java/net/result/sandnode/chain/sender/NameClientChain.java
@@ -5,6 +5,7 @@ import net.result.sandnode.exception.ExpectedMessageException;
 import net.result.sandnode.exception.UnknownSandnodeErrorException;
 import net.result.sandnode.exception.UnprocessedMessagesException;
 import net.result.sandnode.exception.error.SandnodeErrorException;
+import net.result.sandnode.message.RawMessage;
 import net.result.sandnode.message.types.NameRequest;
 import net.result.sandnode.message.types.NameResponse;
 import net.result.sandnode.serverclient.SandnodeClient;
@@ -16,7 +17,7 @@ public class NameClientChain extends ClientChain {
 
     public String getName() throws UnprocessedMessagesException, InterruptedException, ExpectedMessageException,
             UnknownSandnodeErrorException, SandnodeErrorException {
-        send(new NameRequest());
-        return new NameResponse(receive()).content();
+        RawMessage raw = sendAndReceive(new NameRequest());
+        return new NameResponse(raw).content();
     }
 }

--- a/src/main/java/net/result/sandnode/chain/sender/PublicKeyClientChain.java
+++ b/src/main/java/net/result/sandnode/chain/sender/PublicKeyClientChain.java
@@ -18,10 +18,7 @@ public class PublicKeyClientChain extends ClientChain {
 
     public void getPublicKey() throws InterruptedException, ExpectedMessageException, SandnodeErrorException,
             UnknownSandnodeErrorException, CryptoException, UnprocessedMessagesException {
-        send(new PublicKeyRequest());
-
-        RawMessage response = receive();
-
+        RawMessage response = sendAndReceive(new PublicKeyRequest());
         PublicKeyResponse publicKeyResponse = new PublicKeyResponse(response);
         io.setServerKey(publicKeyResponse.keyStorage);
     }

--- a/src/main/java/net/result/sandnode/chain/sender/WhoAmIClientChain.java
+++ b/src/main/java/net/result/sandnode/chain/sender/WhoAmIClientChain.java
@@ -17,10 +17,7 @@ public class WhoAmIClientChain extends ClientChain {
 
     public synchronized String getNickname() throws InterruptedException, ExpectedMessageException,
             UnknownSandnodeErrorException, SandnodeErrorException, UnprocessedMessagesException {
-        send(new WhoAmIRequest());
-
-        RawMessage raw = receive();
-
+        RawMessage raw = sendAndReceive(new WhoAmIRequest());
         return new WhoAmIResponse(raw).getNickname();
     }
 }

--- a/src/main/java/net/result/sandnode/exception/MessageWriteException.java
+++ b/src/main/java/net/result/sandnode/exception/MessageWriteException.java
@@ -1,9 +1,7 @@
 package net.result.sandnode.exception;
 
-import net.result.sandnode.message.Message;
-
-public class MessageWriteException extends SandnodeMessageException {
-    public MessageWriteException(Message snMessage, String message, Throwable e) {
-        super(snMessage, message, e);
+public class MessageWriteException extends SandnodeException {
+    public MessageWriteException(String message, Throwable e) {
+        super(message, e);
     }
 }

--- a/src/main/java/net/result/sandnode/exception/SandnodeMessageException.java
+++ b/src/main/java/net/result/sandnode/exception/SandnodeMessageException.java
@@ -6,11 +6,6 @@ import org.jetbrains.annotations.NotNull;
 public class SandnodeMessageException extends SandnodeException {
     public final Message message;
 
-    public SandnodeMessageException(@NotNull Message snMessage, String message, Throwable e) {
-        super("%s: %s".formatted(message, snMessage), e);
-        this.message = snMessage;
-    }
-
     public SandnodeMessageException(@NotNull Message snMessage, String message) {
         super("%s: %s".formatted(message, snMessage));
         this.message = snMessage;

--- a/src/main/java/net/result/sandnode/serverclient/SandnodeServer.java
+++ b/src/main/java/net/result/sandnode/serverclient/SandnodeServer.java
@@ -63,7 +63,10 @@ public class SandnodeServer {
             String ip = IOController.addressFromSocket(clientSocket).toString();
             LOGGER.info("Client connected {}", ip);
 
-            sessionExecutor.submit(() -> SessionHandler.handle(this, ip, clientSocket));
+            sessionExecutor.submit(() -> {
+                Thread.currentThread().setName(ip);
+                SessionHandler.handle(this, ip, clientSocket);
+            });
         }
 
         sessionExecutor.shutdown();

--- a/src/main/java/net/result/sandnode/serverclient/Session.java
+++ b/src/main/java/net/result/sandnode/serverclient/Session.java
@@ -4,7 +4,6 @@ import net.result.sandnode.chain.ServerChainManager;
 import net.result.sandnode.cluster.Cluster;
 import net.result.sandnode.db.LoginEntity;
 import net.result.sandnode.db.MemberEntity;
-import net.result.sandnode.exception.SandnodeException;
 import net.result.sandnode.util.Address;
 import net.result.sandnode.util.IOController;
 import net.result.sandnode.util.Logout;
@@ -35,7 +34,7 @@ public class Session {
         new Thread(() -> {
             try {
                 Sender.sendingLoop(io);
-            } catch (InterruptedException | SandnodeException e) {
+            } catch (Exception e) {
                 if (io.isConnected()) {
                     LOGGER.error("Error sending message", e);
                 }

--- a/src/main/java/net/result/sandnode/serverclient/SessionHandler.java
+++ b/src/main/java/net/result/sandnode/serverclient/SessionHandler.java
@@ -1,6 +1,5 @@
 package net.result.sandnode.serverclient;
 
-import net.result.sandnode.exception.SandnodeException;
 import net.result.sandnode.message.EncryptedMessage;
 import net.result.sandnode.message.RawMessage;
 import net.result.sandnode.message.util.Connection;
@@ -16,8 +15,6 @@ public class SessionHandler {
     private static final Logger LOGGER = LogManager.getLogger(SessionHandler.class);
 
     static void handle(SandnodeServer server, String ip, Socket clientSocket) {
-        Thread.currentThread().setName(ip);
-
         try {
             InputStream inputStream = StreamReader.inputStream(clientSocket);
             EncryptedMessage encrypted = EncryptedMessage.readMessage(inputStream);
@@ -26,7 +23,7 @@ public class SessionHandler {
             Session session = server.createSession(clientSocket, conn.getOpposite());
             session.io.chainManager.distributeMessage(request);
             session.start();
-        } catch (SandnodeException | InterruptedException e) {
+        } catch (Exception e) {
             LOGGER.error("Error handling session for client {}: {}", ip, e.getMessage(), e);
         }
     }

--- a/src/main/java/net/result/sandnode/util/FileIOUtil.java
+++ b/src/main/java/net/result/sandnode/util/FileIOUtil.java
@@ -20,7 +20,7 @@ import java.util.UUID;
 public class FileIOUtil {
     @FunctionalInterface
     public interface SendMethod {
-        void send(@NotNull Message request) throws UnprocessedMessagesException, InterruptedException;
+        void send(@NotNull Message ignored) throws UnprocessedMessagesException, InterruptedException;
     }
 
     @FunctionalInterface

--- a/src/main/java/net/result/sandnode/util/MessageUtil.java
+++ b/src/main/java/net/result/sandnode/util/MessageUtil.java
@@ -59,10 +59,10 @@ public class MessageUtil {
             decompressed = decryptedBody;
         }
 
-        RawMessage request = new RawMessage(headers, decompressed);
-        request.setHeadersEncryption(headersEncryption);
-        LOGGER.info("Requested by {}", request);
-        return request;
+        RawMessage message = new RawMessage(headers, decompressed);
+        message.setHeadersEncryption(headersEncryption);
+        LOGGER.info("Received {}", message);
+        return message;
     }
 
     public static EncryptedMessage encryptMessage(Message message, KeyStorageRegistry keyStorageRegistry)

--- a/src/main/java/net/result/taulight/chain/receiver/ForwardClientChain.java
+++ b/src/main/java/net/result/taulight/chain/receiver/ForwardClientChain.java
@@ -5,7 +5,6 @@ import net.result.sandnode.chain.ReceiverChain;
 import net.result.sandnode.dto.DEKDTO;
 import net.result.sandnode.encryption.interfaces.KeyStorage;
 import net.result.sandnode.error.Errors;
-import net.result.sandnode.exception.SandnodeException;
 import net.result.sandnode.exception.error.KeyStorageNotFoundException;
 import net.result.sandnode.hubagent.Agent;
 import net.result.sandnode.message.Message;
@@ -26,7 +25,7 @@ public abstract class ForwardClientChain extends ClientChain implements Receiver
     }
 
     @Override
-    public Message handle(RawMessage request) throws SandnodeException, InterruptedException {
+    public Message handle(RawMessage request) throws Exception {
         ForwardResponse response = new ForwardResponse(request);
         ChatMessageViewDTO view = response.getServerMessage();
         ChatMessageInputDTO input = view.message;
@@ -38,8 +37,8 @@ public abstract class ForwardClientChain extends ClientChain implements Receiver
             try {
                 keyStorage = agent.config.loadDEK(client.address, input.keyID);
             } catch (KeyStorageNotFoundException e) {
-                send(new ErrorMessage(Errors.KEY_NOT_FOUND));
-                DEKDTO dto = new DEKListMessage(receive()).list().get(0);
+                RawMessage raw = sendAndReceive(new ErrorMessage(Errors.KEY_NOT_FOUND));
+                DEKDTO dto = new DEKListMessage(raw).list().get(0);
                 keyStorage = dto.decrypt(agent.config.loadPersonalKey(client.address, dto.encryptorID));
                 agent.config.saveDEK(client.address, input.nickname, dto.id, keyStorage);
             }

--- a/src/main/java/net/result/taulight/chain/receiver/ForwardRequestServerChain.java
+++ b/src/main/java/net/result/taulight/chain/receiver/ForwardRequestServerChain.java
@@ -87,9 +87,7 @@ public class ForwardRequestServerChain extends ServerChain implements ReceiverCh
 
             TauHubProtocol.send(session, chat, viewDTO);
 
-            send(new HappyMessage());
-
-            raw = receive();
+            raw = sendAndReceive(new HappyMessage());
         }
     }
 }

--- a/src/main/java/net/result/taulight/chain/sender/ChatClientChain.java
+++ b/src/main/java/net/result/taulight/chain/sender/ChatClientChain.java
@@ -23,14 +23,14 @@ public class ChatClientChain extends ClientChain {
     public synchronized Collection<ChatInfoDTO> getByMember(Collection<ChatInfoPropDTO> infoProps)
             throws InterruptedException, DeserializationException, ExpectedMessageException, SandnodeErrorException,
             UnknownSandnodeErrorException, UnprocessedMessagesException {
-        send(ChatRequest.getByMember(infoProps));
-        return new ChatResponse(receive()).getInfos();
+        var raw = sendAndReceive(ChatRequest.getByMember(infoProps));
+        return new ChatResponse(raw).getInfos();
     }
 
     public synchronized Collection<ChatInfoDTO> getByID(Collection<UUID> chatID, Collection<ChatInfoPropDTO> infoProps)
             throws InterruptedException, ExpectedMessageException, UnknownSandnodeErrorException,
             SandnodeErrorException, DeserializationException, UnprocessedMessagesException {
-        send(ChatRequest.getByID(chatID, infoProps));
-        return new ChatResponse(receive()).getInfos();
+        var raw = sendAndReceive(ChatRequest.getByID(chatID, infoProps));
+        return new ChatResponse(raw).getInfos();
     }
 }

--- a/src/main/java/net/result/taulight/chain/sender/CheckCodeClientChain.java
+++ b/src/main/java/net/result/taulight/chain/sender/CheckCodeClientChain.java
@@ -19,8 +19,7 @@ public class CheckCodeClientChain extends ClientChain {
 
     public CodeDTO check(String code) throws UnprocessedMessagesException, InterruptedException,
             ExpectedMessageException, UnknownSandnodeErrorException, SandnodeErrorException, DeserializationException {
-        send(new CheckCodeRequest(code));
-        RawMessage raw = receive();
+        RawMessage raw = sendAndReceive(new CheckCodeRequest(code));
 
         return new CheckCodeResponse(raw).getCode();
     }

--- a/src/main/java/net/result/taulight/chain/sender/DialogClientChain.java
+++ b/src/main/java/net/result/taulight/chain/sender/DialogClientChain.java
@@ -25,10 +25,7 @@ public class DialogClientChain extends ClientChain {
     public synchronized UUID getDialogID(String nickname)
             throws InterruptedException, DeserializationException, SandnodeErrorException,
             UnknownSandnodeErrorException, UnprocessedMessagesException {
-        send(DialogRequest.getDialogID(nickname));
-
-        RawMessage raw = receive();
-
+        RawMessage raw = sendAndReceive(DialogRequest.getDialogID(nickname));
         return new UUIDMessage(raw).uuid;
     }
 

--- a/src/main/java/net/result/taulight/chain/sender/ForwardRequestClientChain.java
+++ b/src/main/java/net/result/taulight/chain/sender/ForwardRequestClientChain.java
@@ -24,14 +24,11 @@ public class ForwardRequestClientChain extends ClientChain {
     public synchronized UUID message(ChatMessageInputDTO input)
             throws InterruptedException, DeserializationException, ExpectedMessageException,
             UnknownSandnodeErrorException, UnprocessedMessagesException, SandnodeErrorException {
-        send(new ForwardRequest(input));
-
-        RawMessage uuidRaw = receive();
+        RawMessage uuidRaw = sendAndReceive(new ForwardRequest(input));
         uuidRaw.expect(MessageTypes.HAPPY);
         UUID uuid = new UUIDMessage(uuidRaw).uuid;
 
-        RawMessage happyRaw = receive();
-        new HappyMessage(happyRaw);
+        new HappyMessage(receive());
 
         return uuid;
     }

--- a/src/main/java/net/result/taulight/chain/sender/ForwardServerChain.java
+++ b/src/main/java/net/result/taulight/chain/sender/ForwardServerChain.java
@@ -13,6 +13,7 @@ import net.result.sandnode.exception.error.SandnodeErrorException;
 import net.result.sandnode.exception.error.ServerErrorException;
 import net.result.sandnode.message.types.DEKListMessage;
 import net.result.sandnode.message.types.HappyMessage;
+import net.result.sandnode.message.util.MessageTypes;
 import net.result.sandnode.serverclient.Session;
 import net.result.taulight.message.types.ForwardResponse;
 
@@ -37,9 +38,7 @@ public class ForwardServerChain extends ServerChain {
             UUID keyID = res.getServerMessage().message.keyID;
             Optional<EncryptedKeyEntity> opt = encryptedKeyRepo.find(keyID);
             EncryptedKeyEntity entity = opt.orElseThrow(ServerErrorException::new);
-            send(new DEKListMessage(List.of(new DEKDTO(entity))));
-
-            new HappyMessage(receive());
+            sendAndReceive(new DEKListMessage(List.of(new DEKDTO(entity)))).expect(MessageTypes.HAPPY);
         }
     }
 }

--- a/src/main/java/net/result/taulight/chain/sender/MembersClientChain.java
+++ b/src/main/java/net/result/taulight/chain/sender/MembersClientChain.java
@@ -6,6 +6,7 @@ import net.result.sandnode.exception.ExpectedMessageException;
 import net.result.sandnode.exception.UnknownSandnodeErrorException;
 import net.result.sandnode.exception.UnprocessedMessagesException;
 import net.result.sandnode.exception.error.SandnodeErrorException;
+import net.result.sandnode.message.RawMessage;
 import net.result.sandnode.message.UUIDMessage;
 import net.result.sandnode.message.util.Headers;
 import net.result.sandnode.serverclient.SandnodeClient;
@@ -23,7 +24,7 @@ public class MembersClientChain extends ClientChain {
     public synchronized MembersResponseDTO getMembers(UUID chatID)
             throws InterruptedException, ExpectedMessageException, DeserializationException, SandnodeErrorException,
             UnknownSandnodeErrorException, UnprocessedMessagesException {
-        send(new UUIDMessage(new Headers().setType(TauMessageTypes.MEMBERS), chatID));
-        return new MembersResponse(receive()).dto();
+        RawMessage raw = sendAndReceive(new UUIDMessage(new Headers().setType(TauMessageTypes.MEMBERS), chatID));
+        return new MembersResponse(raw).dto();
     }
 }

--- a/src/main/java/net/result/taulight/chain/sender/MessageClientChain.java
+++ b/src/main/java/net/result/taulight/chain/sender/MessageClientChain.java
@@ -7,6 +7,7 @@ import net.result.sandnode.exception.ExpectedMessageException;
 import net.result.sandnode.exception.UnknownSandnodeErrorException;
 import net.result.sandnode.exception.UnprocessedMessagesException;
 import net.result.sandnode.exception.error.SandnodeErrorException;
+import net.result.sandnode.message.RawMessage;
 import net.result.sandnode.serverclient.SandnodeClient;
 import net.result.taulight.dto.ChatMessageViewDTO;
 import net.result.taulight.message.types.MessageRequest;
@@ -22,7 +23,7 @@ public class MessageClientChain extends ClientChain {
     public synchronized PaginatedDTO<ChatMessageViewDTO> getMessages(UUID chatID, int index, int size)
             throws InterruptedException, DeserializationException, ExpectedMessageException, SandnodeErrorException,
             UnknownSandnodeErrorException, UnprocessedMessagesException {
-        send(new MessageRequest(chatID, index, size));
-        return new MessageResponse(receive()).getPaginated();
+        RawMessage raw = sendAndReceive(new MessageRequest(chatID, index, size));
+        return new MessageResponse(raw).getPaginated();
     }
 }

--- a/src/main/java/net/result/taulight/chain/sender/PermissionClientChain.java
+++ b/src/main/java/net/result/taulight/chain/sender/PermissionClientChain.java
@@ -5,7 +5,7 @@ import net.result.sandnode.exception.ExpectedMessageException;
 import net.result.sandnode.exception.UnknownSandnodeErrorException;
 import net.result.sandnode.exception.UnprocessedMessagesException;
 import net.result.sandnode.exception.error.SandnodeErrorException;
-import net.result.sandnode.message.types.HappyMessage;
+import net.result.sandnode.message.util.MessageTypes;
 import net.result.sandnode.serverclient.SandnodeClient;
 import net.result.taulight.db.Permission;
 import net.result.taulight.message.types.PermissionRequest;
@@ -19,27 +19,21 @@ public class PermissionClientChain extends ClientChain {
 
     public void addDefault(UUID chatID, Permission permission) throws UnprocessedMessagesException,
             InterruptedException, UnknownSandnodeErrorException, SandnodeErrorException, ExpectedMessageException {
-        reqRes(PermissionRequest.def("+", chatID, permission));
+        sendAndReceive(PermissionRequest.def("+", chatID, permission)).expect(MessageTypes.HAPPY);
     }
 
     public void removeDefault(UUID chatID, Permission permission) throws UnprocessedMessagesException,
             InterruptedException, UnknownSandnodeErrorException, SandnodeErrorException, ExpectedMessageException {
-        reqRes(PermissionRequest.def("-", chatID, permission));
+        sendAndReceive(PermissionRequest.def("-", chatID, permission)).expect(MessageTypes.HAPPY);
     }
 
     public void addRole(UUID chatID, UUID roleID, Permission permission) throws UnprocessedMessagesException,
             InterruptedException, UnknownSandnodeErrorException, SandnodeErrorException, ExpectedMessageException {
-        reqRes(PermissionRequest.role("+", chatID, roleID, permission));
+        sendAndReceive(PermissionRequest.role("+", chatID, roleID, permission)).expect(MessageTypes.HAPPY);
     }
 
     public void removeRole(UUID chatID, UUID roleID, Permission permission) throws UnprocessedMessagesException,
             InterruptedException, UnknownSandnodeErrorException, SandnodeErrorException, ExpectedMessageException {
-        reqRes(PermissionRequest.role("-", chatID, roleID, permission));
-    }
-
-    private void reqRes(PermissionRequest request) throws UnprocessedMessagesException, InterruptedException,
-            UnknownSandnodeErrorException, SandnodeErrorException, ExpectedMessageException {
-        send(request);
-        new HappyMessage(receive());
+        sendAndReceive(PermissionRequest.role("-", chatID, roleID, permission)).expect(MessageTypes.HAPPY);
     }
 }

--- a/src/main/java/net/result/taulight/chain/sender/ReactionRequestClientChain.java
+++ b/src/main/java/net/result/taulight/chain/sender/ReactionRequestClientChain.java
@@ -5,7 +5,7 @@ import net.result.sandnode.exception.ExpectedMessageException;
 import net.result.sandnode.exception.UnknownSandnodeErrorException;
 import net.result.sandnode.exception.UnprocessedMessagesException;
 import net.result.sandnode.exception.error.SandnodeErrorException;
-import net.result.sandnode.message.types.HappyMessage;
+import net.result.sandnode.message.util.MessageTypes;
 import net.result.sandnode.serverclient.SandnodeClient;
 import net.result.taulight.message.types.ReactionRequest;
 
@@ -20,14 +20,12 @@ public class ReactionRequestClientChain extends ClientChain {
     public synchronized void react(UUID messageID, String reaction)
             throws InterruptedException, ExpectedMessageException, SandnodeErrorException,
             UnknownSandnodeErrorException, UnprocessedMessagesException {
-        send(ReactionRequest.react(messageID, reaction));
-        new HappyMessage(receive());
+        sendAndReceive(ReactionRequest.react(messageID, reaction)).expect(MessageTypes.HAPPY);
     }
 
     public synchronized void unreact(UUID messageID, String reaction)
             throws InterruptedException, ExpectedMessageException, SandnodeErrorException,
             UnknownSandnodeErrorException, UnprocessedMessagesException {
-        send(ReactionRequest.unreact(messageID, reaction));
-        new HappyMessage(receive());
+        sendAndReceive(ReactionRequest.unreact(messageID, reaction)).expect(MessageTypes.HAPPY);
     }
 }

--- a/src/main/java/net/result/taulight/chain/sender/ReactionResponseServerChain.java
+++ b/src/main/java/net/result/taulight/chain/sender/ReactionResponseServerChain.java
@@ -5,7 +5,7 @@ import net.result.sandnode.exception.ExpectedMessageException;
 import net.result.sandnode.exception.UnknownSandnodeErrorException;
 import net.result.sandnode.exception.UnprocessedMessagesException;
 import net.result.sandnode.exception.error.SandnodeErrorException;
-import net.result.sandnode.message.types.HappyMessage;
+import net.result.sandnode.message.util.MessageTypes;
 import net.result.sandnode.serverclient.Session;
 import net.result.taulight.db.MessageEntity;
 import net.result.taulight.db.ReactionEntryEntity;
@@ -20,8 +20,7 @@ public class ReactionResponseServerChain extends ServerChain {
     public synchronized void reaction(ReactionEntryEntity reactionEntry, boolean yourSession)
             throws UnprocessedMessagesException, InterruptedException, ExpectedMessageException,
             UnknownSandnodeErrorException, SandnodeErrorException {
-        send(new ReactionResponse(true, reactionEntry, yourSession));
-        new HappyMessage(receive());
+        sendAndReceive(new ReactionResponse(true, reactionEntry, yourSession)).expect(MessageTypes.HAPPY);
     }
 
     public synchronized void unreaction(
@@ -31,7 +30,7 @@ public class ReactionResponseServerChain extends ServerChain {
             boolean yourSession
     ) throws UnprocessedMessagesException, InterruptedException, ExpectedMessageException,
             UnknownSandnodeErrorException, SandnodeErrorException {
-        send(new ReactionResponse(
+        ReactionResponse response = new ReactionResponse(
                 false,
                 nickname,
                 message.chat().id(),
@@ -39,7 +38,7 @@ public class ReactionResponseServerChain extends ServerChain {
                 reactionType.reactionPackage().name(),
                 reactionType.name(),
                 yourSession
-        ));
-        new HappyMessage(receive());
+        );
+        sendAndReceive(response).expect(MessageTypes.HAPPY);
     }
 }

--- a/src/main/java/net/result/taulight/chain/sender/RoleClientChain.java
+++ b/src/main/java/net/result/taulight/chain/sender/RoleClientChain.java
@@ -20,21 +20,18 @@ public class RoleClientChain extends ClientChain {
 
     public synchronized RolesDTO getRoles(UUID chatID) throws UnprocessedMessagesException, InterruptedException,
             UnknownSandnodeErrorException, SandnodeErrorException, DeserializationException, ExpectedMessageException {
-        send(RoleRequest.getRoles(chatID));
-        return new RoleResponse(receive()).roles();
+        var raw = sendAndReceive(RoleRequest.getRoles(chatID));
+        return new RoleResponse(raw).roles();
     }
 
     public synchronized void addRole(UUID chatID, String roleName) throws UnprocessedMessagesException,
             InterruptedException, UnknownSandnodeErrorException, SandnodeErrorException {
-        send(RoleRequest.addRole(chatID, roleName));
-        receive();
+        sendAndReceive(RoleRequest.addRole(chatID, roleName));
     }
 
     public synchronized void assignRole(UUID chatID, String nickname, String roleName)
             throws UnprocessedMessagesException, InterruptedException, UnknownSandnodeErrorException,
             SandnodeErrorException {
-        send(RoleRequest.assignRole(chatID, roleName, nickname));
-
-        receive();
+        sendAndReceive(RoleRequest.assignRole(chatID, roleName, nickname));
     }
 }

--- a/src/main/java/net/result/taulight/chain/sender/TauMemberSettingsClientChain.java
+++ b/src/main/java/net/result/taulight/chain/sender/TauMemberSettingsClientChain.java
@@ -18,14 +18,15 @@ public class TauMemberSettingsClientChain extends ClientChain {
 
     public TauMemberSettingsResponseDTO get() throws UnprocessedMessagesException, InterruptedException,
             DeserializationException, UnknownSandnodeErrorException, SandnodeErrorException, ExpectedMessageException {
-        send(new TauMemberSettingsRequest());
-        return new TauMemberSettingsResponse(receive()).dto();
+        var raw = sendAndReceive(new TauMemberSettingsRequest());
+        return new TauMemberSettingsResponse(raw).dto();
     }
 
     public TauMemberSettingsResponseDTO setShowStatus(boolean b)
             throws UnprocessedMessagesException, InterruptedException, UnknownSandnodeErrorException,
             SandnodeErrorException, ExpectedMessageException, DeserializationException {
-        send(new TauMemberSettingsRequest(TauMemberSettingsRequest.SHOW_STATUS, String.valueOf(b)));
-        return new TauMemberSettingsResponse(receive()).dto();
+        var message = new TauMemberSettingsRequest(TauMemberSettingsRequest.SHOW_STATUS, String.valueOf(b));
+        var raw = sendAndReceive(message);
+        return new TauMemberSettingsResponse(raw).dto();
     }
 }

--- a/src/main/java/net/result/taulight/chain/sender/UseCodeClientChain.java
+++ b/src/main/java/net/result/taulight/chain/sender/UseCodeClientChain.java
@@ -16,7 +16,7 @@ public class UseCodeClientChain extends ClientChain {
 
     public void use(String code) throws InterruptedException, UnprocessedMessagesException, ExpectedMessageException,
             UnknownSandnodeErrorException, SandnodeErrorException {
-        send(new UseCodeRequest(code));
-        new HappyMessage(receive());
+        var raw = sendAndReceive(new UseCodeRequest(code));
+        new HappyMessage(raw);
     }
 }

--- a/src/main/java/net/result/taulight/message/types/ChatRequest.java
+++ b/src/main/java/net/result/taulight/message/types/ChatRequest.java
@@ -1,6 +1,7 @@
 package net.result.taulight.message.types;
 
 import net.result.sandnode.exception.DeserializationException;
+import net.result.sandnode.exception.ExpectedMessageException;
 import net.result.sandnode.message.MSGPackMessage;
 import net.result.sandnode.message.RawMessage;
 import net.result.sandnode.message.util.Headers;
@@ -20,8 +21,8 @@ public class ChatRequest extends MSGPackMessage<ChatRequestDTO> {
         this(new Headers(), data);
     }
 
-    public ChatRequest(RawMessage raw) throws DeserializationException {
-        super(raw, ChatRequestDTO.class);
+    public ChatRequest(RawMessage raw) throws DeserializationException, ExpectedMessageException {
+        super(raw.expect(TauMessageTypes.CHAT), ChatRequestDTO.class);
     }
 
     public static ChatRequest getByMember(Collection<ChatInfoPropDTO> infoProps) {

--- a/src/main/java/net/result/taulight/util/TauHubProtocol.java
+++ b/src/main/java/net/result/taulight/util/TauHubProtocol.java
@@ -56,7 +56,6 @@ public class TauHubProtocol {
 
         ExecutorService executorService = null;
         try {
-            //noinspection resource
             executorService = Executors.newFixedThreadPool(10);
             List<Future<?>> futures = new ArrayList<>();
 


### PR DESCRIPTION
- Replace separate `send()` and `receive()` calls with `sendAndReceive()` for cleaner and more consistent messaging across chains.
- Update client and server chain logic to expect specific message types where applicable.
- Adjust exception handling to use broader `Exception` where unifying logic.
- Refactor `ExecutorServiceResource` for improved thread management with named threads and typed queues.
- Replace custom thread factories with reusable logic for naming and prioritizing tasks.
- Simplify encryption/decryption thread handling in `Sender` and `Receiver`.
- Improve logging and error handling for encryption failures and fallback message creation.
- Remove redundant `reqRes()` method and inline expectation of `HAPPY` messages for permission operations.